### PR TITLE
[Example] Improve base station configuration

### DIFF
--- a/src/base_station.h
+++ b/src/base_station.h
@@ -73,6 +73,7 @@ public:
 		default:
 			_base_settings.protocol = ProtocolType::RTCMv3;
 			break;
+		}
 	}
 
 	/**

--- a/src/base_station.h
+++ b/src/base_station.h
@@ -55,28 +55,6 @@ public:
 	virtual ~GPSBaseStationSupport() = default;
 
 	/**
-	 * set general RTK base station configuration.
-	 * @param  protocol (0:RTCMv3, 1:RTCMv2, 2:CMR)
-	 */
-	void setBaseGeneralConfig(uint8_t protocol)
-	{
-		switch(protocol){
-		case 0:
-			_base_settings.protocol = ProtocolType::RTCMv3;
-			break;
-		case 1:
-			_base_settings.protocol = ProtocolType::RTCMv2;
-			break;
-		case 2:
-			_base_settings.protocol = ProtocolType::CMR;
-			break;
-		default:
-			_base_settings.protocol = ProtocolType::RTCMv3;
-			break;
-		}
-	}
-
-	/**
 	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
 	 * by averaging the position measurements over time).
 	 * @param survey_in_acc_limit minimum accuracy in 0.1mm
@@ -112,11 +90,6 @@ protected:
 		survey_in,
 		fixed_position
 	};
-	enum class ProtocolType : uint8_t {
-		RTCMv3,
-		RTCMv2,
-		CMR
-	};
 	struct SurveyInSettings {
 		uint32_t acc_limit;
 		uint32_t min_dur;
@@ -129,7 +102,6 @@ protected:
 	};
 	struct BaseSettings {
 		BaseSettingsType type;
-		ProtocolType protocol;
 		union {
 			SurveyInSettings survey_in;
 			FixedPositionSettings fixed_position;

--- a/src/base_station.h
+++ b/src/base_station.h
@@ -55,6 +55,27 @@ public:
 	virtual ~GPSBaseStationSupport() = default;
 
 	/**
+	 * set general RTK base station configuration.
+	 * @param  protocol (0:RTCMv3, 1:RTCMv2, 2:CMR)
+	 */
+	void setBaseGeneralConfig(uint8_t protocol)
+	{
+		switch(protocol){
+		case 0:
+			_base_settings.protocol = ProtocolType::RTCMv3;
+			break;
+		case 1:
+			_base_settings.protocol = ProtocolType::RTCMv2;
+			break;
+		case 2:
+			_base_settings.protocol = ProtocolType::CMR;
+			break;
+		default:
+			_base_settings.protocol = ProtocolType::RTCMv3;
+			break;
+	}
+
+	/**
 	 * set survey-in specs for RTK base station setup (for finding an accurate base station position
 	 * by averaging the position measurements over time).
 	 * @param survey_in_acc_limit minimum accuracy in 0.1mm
@@ -90,6 +111,11 @@ protected:
 		survey_in,
 		fixed_position
 	};
+	enum class ProtocolType : uint8_t {
+		RTCMv3,
+		RTCMv2,
+		CMR
+	};
 	struct SurveyInSettings {
 		uint32_t acc_limit;
 		uint32_t min_dur;
@@ -102,6 +128,7 @@ protected:
 	};
 	struct BaseSettings {
 		BaseSettingsType type;
+		ProtocolType protocol;
 		union {
 			SurveyInSettings survey_in;
 			FixedPositionSettings fixed_position;

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,11 +57,11 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
+#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
+#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,7 +57,7 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
+#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
@@ -386,6 +386,7 @@ int GPSDriverSBF::receive(unsigned timeout)
 // 0b0000_0000 = still decoding
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
+// 0b0000_0100 = RTCM handled
 int GPSDriverSBF::parseChar(const uint8_t b)
 {
 	int ret = 0;
@@ -396,7 +397,7 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
 			decodeInit();
 			_rtcm_parsing->reset();
-			return ret;
+			return 0b0100; // ret
 		}
 	}
 
@@ -638,7 +639,6 @@ int GPSDriverSBF::payloadRxDone()
 			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Todos: formula need approval, 0.01m
 			status.flags = (_buf.payload_pvt_geodetic.mode_type > 0 ? 1 : 0) | (_survey_active & 1) << 1; 
 			surveyInStatus(status);
-			qDebug() << "Sending survey";
 		}
 
 		//SBF_DEBUG("PVTGeodetic handled");

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -55,8 +55,8 @@
 #define MSG_SIZE                    100 // size of the message to be sent to the receiver.
 
 /**** Trace macros, disable for production builds */
-#define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
-#define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
+#define SBF_TRACE_PARSER(...)   {GPS_INFO(__VA_ARGS__);}    /* decoding progress in parse_char() */
+#define SBF_TRACE_RXMSG(...)    {GPS_INFO(__VA_ARGS__);}    /* Rx msgs in payload_rx_done() */
 #define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
 
 /**** Warning macros, disable to save memory */
@@ -226,20 +226,7 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		_rtcm_parsing->reset();
 	}
 
-	switch(_base_settings.protocol){
-		case ProtocolType::CMR:
-			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_CMR, SBF_CONFIG_TIMEOUT);
-			break;
-
-		case ProtocolType::RTCMv2:
-			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM2, SBF_CONFIG_TIMEOUT);
-			break;
-		
-		case ProtocolType::RTCMv3:
-		default:
-			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM3, SBF_CONFIG_TIMEOUT);
-			break;
-	}
+	sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM3, SBF_CONFIG_TIMEOUT);
 	
 	if (_output_mode == OutputMode::RTCM) {
 		switch(_base_settings.type){
@@ -427,7 +414,7 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 		break;
 
 	// Expecting payload
-	case SBF_DECODE_PAYLOAD: SBF_TRACE_PARSER(".");
+	case SBF_DECODE_PAYLOAD: // SBF_TRACE_PARSER(".");
 
 		ret = payloadRxAdd(b); // add a payload byte
 
@@ -509,6 +496,7 @@ int GPSDriverSBF::payloadRxDone()
 	if (_buf.length <= 4 ||
 	    _buf.length > _rx_payload_index ||
 	    _buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
+		SBF_TRACE_RXMSG("Rx Unknow");
 		return 0;
 	}
 
@@ -634,9 +622,9 @@ int GPSDriverSBF::payloadRxDone()
 			SurveyInStatus status{};
 			status.latitude = _gps_position->latitude_deg;
 			status.longitude = _gps_position->longitude_deg;
-			status.altitude = _gps_position->altitude_ellipsoid_m; // Todo: Need check if this value use the WGS84 format.
+			status.altitude = _gps_position->altitude_ellipsoid_m;
 			status.duration = _survey_active ? (float)(gps_absolute_time() - _survey_activation_date) / 1000000.0f : 0;
-			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Todos: formula need approval, 0.01m
+			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Value in mm
 			status.flags = (_buf.payload_pvt_geodetic.mode_type > 0 ? 1 : 0) | (_survey_active & 1) << 1; 
 			surveyInStatus(status);
 			ret |= 4; // RTCM infos have been updated
@@ -725,6 +713,7 @@ int GPSDriverSBF::payloadRxDone()
 		break;
 
 	default:
+		SBF_TRACE_RXMSG("Rx other.");
 		break;
 	}
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,11 +57,11 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
+#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
+#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)
@@ -334,7 +334,7 @@ bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 // 0b0000_0000 = no message handled (not set up yet)
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
-// 0b0000_0100 = RTCM handled
+// 0b0000_0100 = base station update (RTCM message or base station position)
 int GPSDriverSBF::receive(unsigned timeout)
 {
 	int handled = 0;
@@ -386,7 +386,7 @@ int GPSDriverSBF::receive(unsigned timeout)
 // 0b0000_0000 = still decoding
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
-// 0b0000_0100 = RTCM handled
+// 0b0000_0100 = base station update
 int GPSDriverSBF::parseChar(const uint8_t b)
 {
 	int ret = 0;
@@ -639,6 +639,7 @@ int GPSDriverSBF::payloadRxDone()
 			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Todos: formula need approval, 0.01m
 			status.flags = (_buf.payload_pvt_geodetic.mode_type > 0 ? 1 : 0) | (_survey_active & 1) << 1; 
 			surveyInStatus(status);
+			ret |= 4; // RTCM infos have been updated
 		}
 
 		//SBF_DEBUG("PVTGeodetic handled");

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -55,13 +55,13 @@
 #define MSG_SIZE                    100 // size of the message to be sent to the receiver.
 
 /**** Trace macros, disable for production builds */
-#define SBF_TRACE_PARSER(...)   {GPS_INFO(__VA_ARGS__);}    /* decoding progress in parse_char() */
-#define SBF_TRACE_RXMSG(...)    {GPS_INFO(__VA_ARGS__);}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
+#define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
+#define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
+#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
 
 /**** Warning macros, disable to save memory */
-#define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
+#define SBF_WARN(...)        {/*GPS_WARN(__VA_ARGS__);*/}
+#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)
@@ -414,7 +414,7 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 		break;
 
 	// Expecting payload
-	case SBF_DECODE_PAYLOAD: // SBF_TRACE_PARSER(".");
+	case SBF_DECODE_PAYLOAD: SBF_TRACE_PARSER(".");
 
 		ret = payloadRxAdd(b); // add a payload byte
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,11 +57,11 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
+#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
+#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,11 +57,11 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
+#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
+#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)
@@ -226,7 +226,6 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		_rtcm_parsing->reset();
 	}
 
-	SBF_DEBUG("Configure for protocol: %d", _base_settings.protocol);
 	switch(_base_settings.protocol){
 		case ProtocolType::CMR:
 			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_CMR, SBF_CONFIG_TIMEOUT);
@@ -276,7 +275,7 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 bool GPSDriverSBF::sendMessage(const char *msg)
 {
 	// Send message
-	SBF_DEBUG("Send MSG: %s", msg);
+	SBF_DEBUG("Ho Send MSG: %s", msg);
 	int length = static_cast<int>(strlen(msg));
 
 	return (write(msg, length) == length);
@@ -284,7 +283,7 @@ bool GPSDriverSBF::sendMessage(const char *msg)
 
 bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 {
-	SBF_INFO("Send MSG: %s", msg);
+	SBF_INFO("Ho Send MSG: %s", msg);
 
 	// Send message
 	int length = static_cast<int>(strlen(msg));
@@ -335,6 +334,7 @@ bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 // 0b0000_0000 = no message handled (not set up yet)
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
+// 0b0000_0100 = RTCM handled
 int GPSDriverSBF::receive(unsigned timeout)
 {
 	int handled = 0;
@@ -560,7 +560,7 @@ int GPSDriverSBF::payloadRxDone()
 				// other data, but it's really large: >800B)
 				_satellite_info->timestamp = gps_absolute_time();
 				_satellite_info->count = _gps_position->satellites_used;
-				ret = 2;
+				ret |= 2;
 			}
 
 		} else {

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -226,21 +226,47 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		_rtcm_parsing->reset();
 	}
 
+	SBF_DEBUG("Configure for protocol: %d", _base_settings.protocol);
+	switch(_base_settings.protocol){
+		case ProtocolType::CMR:
+			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_CMR, SBF_CONFIG_TIMEOUT);
+			break;
+
+		case ProtocolType::RTCMv2:
+			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM2, SBF_CONFIG_TIMEOUT);
+			break;
+		
+		case ProtocolType::RTCMv3:
+		default:
+			sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM3, SBF_CONFIG_TIMEOUT);
+			break;
+	}
+	
 	if (_output_mode == OutputMode::RTCM) {
-		if (_base_settings.type == BaseSettingsType::fixed_position) {
+		switch(_base_settings.type){
+		case(BaseSettingsType::fixed_position):
 			snprintf(msg, sizeof(msg), SBF_CONFIG_RTCM_STATIC_COORDINATES,
-				 _base_settings.settings.fixed_position.latitude,
-				 _base_settings.settings.fixed_position.longitude,
-				 static_cast<double>(_base_settings.settings.fixed_position.altitude));
+				_base_settings.settings.fixed_position.latitude,
+				_base_settings.settings.fixed_position.longitude,
+				static_cast<double>(_base_settings.settings.fixed_position.altitude));
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
+			
 			snprintf(msg, sizeof(msg), SBF_CONFIG_RTCM_STATIC_OFFSET, 0.0, 0.0, 0.0);
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
+			
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC1, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC2, SBF_CONFIG_TIMEOUT);
+			break;
 
-		} else {
-			sendMessageAndWaitForAck(SBF_CONFIG_RTCM, SBF_CONFIG_TIMEOUT);
+		case(BaseSettingsType::survey_in):
+		default:
+			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_SURVEY_IN, SBF_CONFIG_TIMEOUT);
+			break;
 		}
+	
+		sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATUS, SBF_CONFIG_TIMEOUT);	
+		_survey_active = true;
+		_survey_activation_date = gps_absolute_time();
 	}
 
 	_configured = true;
@@ -258,7 +284,7 @@ bool GPSDriverSBF::sendMessage(const char *msg)
 
 bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 {
-	SBF_DEBUG("Send MSG: %s", msg);
+	SBF_INFO("Send MSG: %s", msg);
 
 	// Send message
 	int length = static_cast<int>(strlen(msg));
@@ -344,12 +370,13 @@ int GPSDriverSBF::receive(unsigned timeout)
 		}
 
 		if (handled > 0) {
+			SBF_INFO("Handled : %i", handled);
 			return handled;
 		}
 
 		// abort after timeout if no useful packets received
 		if (time_started + timeout * 1000 < gps_absolute_time()) {
-			SBF_DEBUG("timed out, returning");
+			SBF_DEBUG("timed out after %d ms, returning", timeout);
 			return -1;
 		}
 	}
@@ -599,6 +626,21 @@ int GPSDriverSBF::payloadRxDone()
 		_rate_count_vel++;
 		_rate_count_lat_lon++;
 		ret |= (_msg_status == 7) ? 1 : 0;
+
+
+		// In RTCM mode, PVTGeodetic is used to get base station survey-in
+		if(_output_mode == OutputMode::RTCM){
+			SurveyInStatus status{};
+			status.latitude = _gps_position->latitude_deg;
+			status.longitude = _gps_position->longitude_deg;
+			status.altitude = _gps_position->altitude_ellipsoid_m; // Todo: Need check if this value use the WGS84 format.
+			status.duration = _survey_active ? (float)(gps_absolute_time() - _survey_activation_date) / 1000000.0f : 0;
+			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Todos: formula need approval, 0.01m
+			status.flags = (_buf.payload_pvt_geodetic.mode_type > 0 ? 1 : 0) | (_survey_active & 1) << 1; 
+			surveyInStatus(status);
+			qDebug() << "Sending survey";
+		}
+
 		//SBF_DEBUG("PVTGeodetic handled");
 		break;
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,11 +57,11 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
+#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
 
 /**** Warning macros, disable to save memory */
 #define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
-#define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
+#define SBF_DEBUG(...)       {GPS_WARN(__VA_ARGS__);}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
 			   satellite_info_s *satellite_info, float heading_offset, float pitch_offset)
@@ -275,7 +275,7 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 bool GPSDriverSBF::sendMessage(const char *msg)
 {
 	// Send message
-	SBF_DEBUG("Ho Send MSG: %s", msg);
+	SBF_DEBUG("Send MSG: %s", msg);
 	int length = static_cast<int>(strlen(msg));
 
 	return (write(msg, length) == length);
@@ -283,7 +283,7 @@ bool GPSDriverSBF::sendMessage(const char *msg)
 
 bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 {
-	SBF_INFO("Ho Send MSG: %s", msg);
+	SBF_INFO("Send MSG: %s", msg);
 
 	// Send message
 	int length = static_cast<int>(strlen(msg));

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -63,24 +63,33 @@
 
 #define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n"
 
-#define SBF_CONFIG_DISABLE_OUTPUT "setDataInOut,%s%d,,-RTCMv3\n"
+#define SBF_CONFIG_STATUS "setSBFOutput, Stream1, %s, +ReceiverStatus, msec500\n"
 
-#define SBF_CONFIG_RTCM "" \
-	"setDataInOut, USB1, Auto, RTCMv3\n" \
-	"setPVTMode, Static, All, auto\n"
+#define SBF_CONFIG_DISABLE_OUTPUT "setDataInOut,%s%d,,-RTCMv3-RTCMv2-CMRv2\n"
 
-#define SBF_CONFIG_RTCM_STATIC1 "" \
-	"setReceiverDynamics, Low, Static\n"
+/* RTK Protocol */
+#define SBF_CONFIG_OUTPUT_RTCM3	"setDataInOut, USB1, Auto, RTCMv3+SBF\n"
 
-#define SBF_CONFIG_RTCM_STATIC2 "" \
-	"setPVTMode, Static, , Geodetic1\n"
+#define SBF_CONFIG_OUTPUT_RTCM2	"setDataInOut, USB1, Auto, RTCMv2+SBF\n"
 
-#define SBF_CONFIG_RTCM_STATIC_COORDINATES "" \
-	"setStaticPosGeodetic, Geodetic1, %f, %f, %f\n"
+#define SBF_CONFIG_OUTPUT_CMR	"setDataInOut, USB1, Auto, CMRv2+SBF\n"
+	
+/* RTK Fixed */
+#define SBF_CONFIG_RTCM_STATIC_COORDINATES "setStaticPosGeodetic, Geodetic1, %f, %f, %f\n"
 
-#define SBF_CONFIG_RTCM_STATIC_OFFSET "" \
-	"setAntennaOffset, Main, %f, %f, %f\n"
+#define SBF_CONFIG_RTCM_STATIC_OFFSET "setAntennaOffset, Main, %f, %f, %f\n"
 
+#define SBF_CONFIG_RTCM_STATIC1 "setReceiverDynamics, Low, Static\n"
+
+#define SBF_CONFIG_RTCM_STATIC2 "setPVTMode, Static, , Geodetic1\n"
+
+/* RTK Auto */
+#define SBF_CONFIG_RTCM_SURVEY_IN "setPVTMode, Static, All, auto\n"
+
+/* Status */
+#define SBF_CONFIG_RTCM_STATUS "setSBFOutput, Stream1, USB1, +PVTGeodetic, msec500\n"
+
+/* Reset */
 #define SBF_CONFIG_RESET_HOT "" \
 	SBF_CONFIG_FORCE_INPUT"ExeResetReceiver, soft, none\n"
 
@@ -424,6 +433,8 @@ private:
 
 	const float _heading_offset;
 	const float _pitch_offset;
+	bool _survey_active{false};
+	gps_abstime _survey_activation_date{0};
 };
 
 uint16_t crc16(const uint8_t *buf, uint32_t len);


### PR DESCRIPTION
This PR contains improvement regarding :

- Possibility to choose output mode (RTCMv3, RTCMv2, CMRv2) for base station.
- Add base station information using PVTGeodetic messages.
- Re-order sbf message definition in a more cleaver way. 
- Return special ret code when receiving message for base station infos to avoid timeout for the receiver.

These changes are part of another PR on QGC to add base station configuration menu : [Link need to be updated] https://github.com/Louis-max-H/qgroundcontrol/pull/1